### PR TITLE
Added sv_root_info for inspection of ROOT files with uproot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ requirements = [
     'memory_profiler>=0.54',
     'numexpr',
     'numpy>=1.15.0',
+    'pandas',
     'plumbum',
     # 'python-gitlab>=1.8.0',
     # as long as 1.8.0 is not published, take master
@@ -70,6 +71,7 @@ requirements = [
     'python-gitlab>=1.7.0',
     'pyyaml',
     'scipy',
+    'tabulate',
     'tqdm',
     'uproot',
     'xhtml2pdf',

--- a/skvalidate/commands/root_info.py
+++ b/skvalidate/commands/root_info.py
@@ -46,7 +46,7 @@ def cli(input_file, output_file, show_unreadable, show_empty, verbose):
     if verbose and not (show_unreadable or show_empty):
         print(tabulate(df, headers='keys', tablefmt='psql'))
     if show_unreadable:
-        unreadable = df[df.uproot_readable == False]
+        unreadable = df[not df.uproot_readable]
         if unreadable.empty:
             print('All file contents can be read by uproot')
         else:
@@ -54,7 +54,7 @@ def cli(input_file, output_file, show_unreadable, show_empty, verbose):
             print(tabulate(unreadable, headers='keys', tablefmt='psql'))
     print()
     if show_empty:
-        empty = df[df.is_empty == True]
+        empty = df[df.is_empty]
         if empty.empty:
             print('All file contents are filled')
         else:

--- a/skvalidate/commands/root_info.py
+++ b/skvalidate/commands/root_info.py
@@ -1,6 +1,7 @@
 """
 Read a ROOT file and reports information about its content (names, sizes, types)
 """
+from __future__ import print_function
 import click
 import pandas as pd
 from tabulate import tabulate
@@ -13,16 +14,24 @@ def info(input_file):
     f = uproot.open(input_file)
 
     data = []
-    labels = ['name', 'uproot_type', 'compressedbytes', 'uncompressedbytes', 'hasStreamer', 'uproot_readable']
+    labels = ['name', 'uproot_type', 'compressedbytes',
+              'uncompressedbytes', 'hasStreamer', 'uproot_readable', 'is_empty']
     for name, obj in _walk(f):
         canRead = False
+        is_empty = False
         try:
-            obj.array()
+            a = obj.array()
+            if a is None:
+                is_empty = True
+            # try to access first element
+            a[0]
             canRead = True
-        except Exception:
-            pass
+        except Exception as e:
+            print(e)
         hasStreamer = obj._streamer is not None
-        data.append((name, obj.interpretation, obj.compressedbytes(), obj.uncompressedbytes(), hasStreamer, canRead))
+        data.append(
+            (name, obj.interpretation, obj.compressedbytes(), obj.uncompressedbytes(), hasStreamer, canRead, is_empty)
+        )
     return pd.DataFrame.from_records(data, columns=labels)
 
 
@@ -30,10 +39,11 @@ def info(input_file):
 @click.argument('input_file', type=click.Path(exists=True))
 @click.option('-o', '--output-file', help="CSV output file for information", type=click.Path(), default='root_info.csv')
 @click.option('--show-unreadable', help="print the file entries that uproot cannot read", default=False, is_flag=True)
+@click.option('--show-empty', help="print the file entries that are empty", default=False, is_flag=True)
 @click.option('-v', '--verbose', help="print information", default=False, is_flag=True)
-def cli(input_file, output_file, show_unreadable, verbose):
+def cli(input_file, output_file, show_unreadable, show_empty, verbose):
     df = info(input_file)
-    if verbose and not show_unreadable:
+    if verbose and not (show_unreadable or show_empty):
         print(tabulate(df, headers='keys', tablefmt='psql'))
     if show_unreadable:
         unreadable = df[df.uproot_readable == False]
@@ -42,4 +52,12 @@ def cli(input_file, output_file, show_unreadable, verbose):
         else:
             print('The following file contents cannot be read by uproot')
             print(tabulate(unreadable, headers='keys', tablefmt='psql'))
+    print()
+    if show_empty:
+        empty = df[df.is_empty == True]
+        if empty.empty:
+            print('All file contents are filled')
+        else:
+            print('The following file contents are empty')
+            print(tabulate(empty, headers='keys', tablefmt='psql'))
     df.to_csv(output_file)

--- a/skvalidate/commands/root_info.py
+++ b/skvalidate/commands/root_info.py
@@ -1,0 +1,45 @@
+"""
+Read a ROOT file and reports information about its content (names, sizes, types)
+"""
+import click
+import pandas as pd
+from tabulate import tabulate
+import uproot
+
+from skvalidate.io import _walk
+
+
+def info(input_file):
+    f = uproot.open(input_file)
+
+    data = []
+    labels = ['name', 'uproot_type', 'compressedbytes', 'uncompressedbytes', 'hasStreamer', 'uproot_readable']
+    for name, obj in _walk(f):
+        canRead = False
+        try:
+            obj.array()
+            canRead = True
+        except Exception:
+            pass
+        hasStreamer = obj._streamer is not None
+        data.append((name, obj.interpretation, obj.compressedbytes(), obj.uncompressedbytes(), hasStreamer, canRead))
+    return pd.DataFrame.from_records(data, columns=labels)
+
+
+@click.command(help=__doc__)
+@click.argument('input_file', type=click.Path(exists=True))
+@click.option('-o', '--output-file', help="CSV output file for information", type=click.Path(), default='root_info.csv')
+@click.option('--show-unreadable', help="print the file entries that uproot cannot read", default=False, is_flag=True)
+@click.option('-v', '--verbose', help="print information", default=False, is_flag=True)
+def cli(input_file, output_file, show_unreadable, verbose):
+    df = info(input_file)
+    if verbose and not show_unreadable:
+        print(tabulate(df, headers='keys', tablefmt='psql'))
+    if show_unreadable:
+        unreadable = df[df.uproot_readable == False]
+        if unreadable.empty:
+            print('All file contents can be read by uproot')
+        else:
+            print('The following file contents cannot be read by uproot')
+            print(tabulate(unreadable, headers='keys', tablefmt='psql'))
+    df.to_csv(output_file)


### PR DESCRIPTION
Adds `sv_root_info` to display information about ROOT files, e.g.

```bash
sv_root_info continuous_integration_101.root --show-unreadable
The following file contents cannot be read by uproot
+----+-----------------------------------------+---------------+-------------------+---------------------+---------------+-------------------+
|    | name                                    | uproot_type   |   compressedbytes |   uncompressedbytes | hasStreamer   | uproot_readable   |
|----+-----------------------------------------+---------------+-------------------+---------------------+---------------+-------------------|
| 16 | DataTree;1.Event.tracks.sCreatorProcess | asstring(7)   |              8289 |             1015137 | True          | False             |
| 17 | DataTree;1.Event.tracks.sParticleName   | asstring(7)   |             14207 |             2264904 | True          | False             |
+----+-----------------------------------------+---------------+-------------------+---------------------+---------------+-------------------+
```