### PR TITLE
Add check in case we get a pair of Nones from load_values

### DIFF
--- a/skvalidate/commands/root_diff.py
+++ b/skvalidate/commands/root_diff.py
@@ -34,12 +34,12 @@ def _process(name, values, output_path):
             msg = 'FAILED (test: {:0.3f}): {}'.format(evaluationValue, image)
         except TypeError as e:
             msg = 'ERROR: Cannot draw (value type: {0}, reason: {1})'.format(
-                values['original'].dtype,
+                "Unknown" if values['original'] is None else values['original'].dtype,
                 str(e),
             )
     if status == compare.UNKNOWN:
         msg = 'WARNING: Unable to compare (value type: {0}, reason: {1})'.format(
-            values['original'].dtype,
+            "Unknown" if values['original'] is None else values['original'].dtype,
             values['reason'],
         )
         color = colors.Orange3
@@ -144,6 +144,8 @@ def cli(file_under_test, reference_file, output_path, report_file, prefix, n_cor
 
 def _reset_infinities(comparison):
     for name, values in comparison.items():
+        if values['original'] is None or values['reference'] is None:
+            continue
         if values['original'].dtype.kind in {'U', 'S', 'O'}:
             continue
         if values['reference'].dtype.kind in {'U', 'S', 'O'}:

--- a/skvalidate/compare/__init__.py
+++ b/skvalidate/compare/__init__.py
@@ -68,6 +68,9 @@ def compare_two_root_files(file1, file2, tolerance=0.02):
             status = FAILED
             reason = 'file1 is empty' if np.size(value1) > 0 else 'reference file is empty'
             diff = value1 if np.size(value1) > 0 else value2
+        elif value1 is None or value2 is None:
+            status = UNKNOWN
+            reason = 'Cannot convert data to numpy array'
         else:
             ks_statistic, pvalue = stats.ks_2samp(value2, value1)
 


### PR DESCRIPTION
This is potentially a temporary fix to try and help the LZ validation pipeline which seems to be hitting this issue.

I've not been able to test it very thoroughly, however, and so I wasn't sure how to extend the tests here to check this problem I'm afraid.