### PR TITLE
Sanatising report configs

### DIFF
--- a/.ci/ci_report.yml
+++ b/.ci/ci_report.yml
@@ -1,10 +1,10 @@
 
-template: {{scikit_validate}}/data/templates/report/default/summary.md
+template: "{{scikit_validate}}/data/templates/report/default/summary.md"
 title: "scikit-validate DEMO report"
 
 sections:
   pipeline_report:
-    template: {{scikit_validate}}/data/templates/report/default/pipeline.md
+    template: "{{scikit_validate}}/data/templates/report/default/pipeline.md"
     pipeline:
       function: skvalidate.report.demo.get_pipeline_url
     jobs:
@@ -21,7 +21,7 @@ sections:
       symbol_unkown: '&#10067;'
 
   validation_report:
-    template: {{scikit_validate}}/data/templates/report/default/validation.md
+    template: "{{scikit_validate}}/data/templates/report/default/validation.md"
     validation:
       function: skvalidate.report.validation.produce_validation_report
       validation_json: output/validate/root_comparison.json
@@ -33,7 +33,7 @@ sections:
 
 
   performance_report:
-    template: {{scikit_validate}}/data/templates/report/default/performance.md
+    template: "{{scikit_validate}}/data/templates/report/default/performance.md"
     download:
       input/performance_metrics.json: gitlab://validate:metric_pipeline/output/metrics/performance_metrics.json
       input/performance_metrics_ref.json: gitlab://validate:metric_pipeline_ref/output/metrics/performance_metrics.json
@@ -50,11 +50,11 @@ sections:
       symbol_same: '&#10134;'
 
   file_report:
-    template: {{scikit_validate}}/data/templates/report/default/file_metrics.md
+    template: "{{scikit_validate}}/data/templates/report/default/file_metrics.md"
     comparison:
       function: skvalidate.report.get_metrics
-      metrics_json: {{scikit_validate}}/data/examples/file_metrics.json
-      metrics_ref_json: {{scikit_validate}}/data/examples/file_metrics_ref.json
+      metrics_json: "{{scikit_validate}}/data/examples/file_metrics.json"
+      metrics_ref_json: "{{scikit_validate}}/data/examples/file_metrics_ref.json"
       keys:
         - size_in_mb
       symbol_up: '&#10138;'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ six
 Sphinx==1.7.1
 sphinxcontrib-apidoc==0.3.0
 sphinx_rtd_theme==0.1.9
-pytest==3.4.2
+pytest==4.3.0
 pytest-runner==2.11.1
 gitchangelog==3.0.4
-hypothesis
+hypothesis==4.28.2

--- a/skvalidate/data/config/report/demo.yml
+++ b/skvalidate/data/config/report/demo.yml
@@ -1,10 +1,10 @@
 
-template: {{scikit_validate}}/data/templates/report/default/summary.md
+template: "{{scikit_validate}}/data/templates/report/default/summary.md"
 title: "scikit-validate DEMO report"
 
 sections:
   pipeline_report:
-    template: {{scikit_validate}}/data/templates/report/default/pipeline.md
+    template: "{{scikit_validate}}/data/templates/report/default/pipeline.md"
     pipeline:
       function: skvalidate.report.demo.get_pipeline_url
     jobs:
@@ -13,39 +13,39 @@ sections:
         - build
         - test
         - validation
-      software_versions: {{scikit_validate}}/data/examples/software_versions.json
+      software_versions: "{{scikit_validate}}/data/examples/software_versions.json"
       symbol_success: '&#9989;'
       symbol_failed: '&#10060;'
       symbol_unkown: '&#10067;'
 
   validation_report:
-    template: {{scikit_validate}}/data/templates/report/default/validation.md
+    template: "{{scikit_validate}}/data/templates/report/default/validation.md"
     validation:
       function: skvalidate.report.demo.get_full_validations
       validation_detail:
-        validation1: {{scikit_validate}}/data/examples/root_diff/test_1_2/root_diff.json
-        validation2: {{scikit_validate}}/data/examples/root_diff/test_1_3/root_diff.json
-        validation3: {{scikit_validate}}/data/examples/root_diff/test_1_3/root_diff.json
+        validation1: "{{scikit_validate}}/data/examples/root_diff/test_1_2/root_diff.json"
+        validation2: "{{scikit_validate}}/data/examples/root_diff/test_1_3/root_diff.json"
+        validation3: "{{scikit_validate}}/data/examples/root_diff/test_1_3/root_diff.json"
 
 
   performance_report:
-    template: {{scikit_validate}}/data/templates/report/default/performance.md
+    template: "{{scikit_validate}}/data/templates/report/default/performance.md"
     comparison:
       function: skvalidate.report.get_metrics
-      metrics_json: {{scikit_validate}}/data/examples/performance_metrics.json
-      metrics_ref_json: {{scikit_validate}}/data/examples/performance_metrics_ref.json
-      profile: {{scikit_validate}}/data/examples/memory_profile.dat
-      profile_ref: {{scikit_validate}}/data/examples/memory_profile_ref.dat
+      metrics_json: "{{scikit_validate}}/data/examples/performance_metrics.json"
+      metrics_ref_json: "{{scikit_validate}}/data/examples/performance_metrics_ref.json"
+      profile: "{{scikit_validate}}/data/examples/memory_profile.dat"
+      profile_ref: "{{scikit_validate}}/data/examples/memory_profile_ref.dat"
       symbol_up: '&#10138;'
       symbol_down: '&#10136;'
       symbol_same: '&#10134;'
 
   file_report:
-    template: {{scikit_validate}}/data/templates/report/default/file_metrics.md
+    template: "{{scikit_validate}}/data/templates/report/default/file_metrics.md"
     comparison:
       function: skvalidate.report.get_metrics
-      metrics_json: {{scikit_validate}}/data/examples/file_metrics.json
-      metrics_ref_json: {{scikit_validate}}/data/examples/file_metrics_ref.json
+      metrics_json: "{{scikit_validate}}/data/examples/file_metrics.json"
+      metrics_ref_json: "{{scikit_validate}}/data/examples/file_metrics_ref.json"
       keys:
         - size_in_mb
       symbol_up: '&#10138;'

--- a/skvalidate/data/config/report/gitlab_report.yml
+++ b/skvalidate/data/config/report/gitlab_report.yml
@@ -1,6 +1,7 @@
+---
 
-output_file: {{ output_file | 'report.md' }}
-template: {{scikit_validate}}/data/templates/report/default/summary.md
+output_file: "{{ output_file | 'report.md' }}"
+template: "{{scikit_validate}}/data/templates/report/default/summary.md"
 output_url:
   function: skvalidate.gitlab.get_output_url
 pipeline_url:
@@ -9,7 +10,7 @@ title: "Default Gitlab Report"
 
 sections:
   pipeline_report:
-    template: {{scikit_validate}}/data/templates/report/default/pipeline.md
+    template: "{{scikit_validate}}/data/templates/report/default/pipeline.md"
     pipeline:
       function: skvalidate.report.demo.get_pipeline_url
     jobs:
@@ -18,13 +19,13 @@ sections:
         - build
         - test
         - validation
-      software_versions: {{scikit_validate}}/data/examples/software_versions.json
+      software_versions: "{{scikit_validate}}/data/examples/software_versions.json"
       symbol_success: '&#9989;'
       symbol_failed: '&#10060;'
       symbol_unkown: '&#10067;'
 
   validation_report:
-    template: {{scikit_validate}}/data/templates/report/default/validation.md
+    template: "{{scikit_validate}}/data/templates/report/default/validation.md"
     validation:
       function: skvalidate.gitlab.get_validation_report
       stage: validation
@@ -34,7 +35,7 @@ sections:
 
 
   performance_report:
-    template: {{scikit_validate}}/data/templates/report/default/performance.md
+    template: "{{scikit_validate}}/data/templates/report/default/performance.md"
     metrics:
       function: skvalidate.report.get_metrics
       metrics_json: metrics.json
@@ -43,7 +44,7 @@ sections:
       symbol_same: '&#10134;'
 
   file_report:
-    template: {{scikit_validate}}/data/templates/report/default/performance.md
+    template: "{{scikit_validate}}/data/templates/report/default/performance.md"
     file_metrics:
       function: skvalidate.report.get_metrics
       metrics_json: file_metrics.json

--- a/skvalidate/io/__init__.py
+++ b/skvalidate/io/__init__.py
@@ -55,8 +55,13 @@ def _walk(obj, name=None):
     else:
         for k in sorted(obj.keys()):
             # if there is a '.' the first part of k it will be a duplicate
-            new_k = k.decode("utf-8").split('.')[-1]
-            new_name = '.'.join([name, new_k]) if name else new_k
+            k_str = k.decode("utf-8")
+            tokens = k_str.split('.')
+            new_name = name if name else k_str
+            for t in tokens:
+                if new_name.endswith(t):
+                    continue
+                new_name = '.'.join([new_name, t])
             for n, o in _walk(obj[k], new_name):
                 yield n, o
 

--- a/skvalidate/report/__init__.py
+++ b/skvalidate/report/__init__.py
@@ -123,11 +123,14 @@ def read_config(path):
 
 def _render_config(config_tpl):
     config = {}
-    for key, value in config_tpl:
+    for key, value in config_tpl.items():
         if isinstance(value, dict):
             config[key] = _render_config(value)
         else:
-            config[key] = Template(value).render(scikit_validate=__skvalidate_root__)
+            if isinstance(value, list):
+                config[key] = [Template(v).render(scikit_validate=__skvalidate_root__) for v in value]
+            else:
+                config[key] = Template(value).render(scikit_validate=__skvalidate_root__)
     return config
 
 

--- a/skvalidate/report/__init__.py
+++ b/skvalidate/report/__init__.py
@@ -117,9 +117,17 @@ class Section(object):
 
 def read_config(path):
     with open(path) as f:
-        config_tpl = Template(f.read())
-    config = config_tpl.render(scikit_validate=__skvalidate_root__)
-    config = yaml.load(config)
+        config_tpl = yaml.load(f.read())
+    return _render_config(config_tpl)
+
+
+def _render_config(config_tpl):
+    config = {}
+    for key, value in config_tpl:
+        if isinstance(value, dict):
+            config[key] = _render_config(value)
+        else:
+            config[key] = Template(value).render(scikit_validate=__skvalidate_root__)
     return config
 
 


### PR DESCRIPTION
Reversing the order of template rendering from `render template` &rarr; `parse YAML` to `parse YAML` &rarr; `render template`.

As Jim suggested, this should make parsing more reliable and secure, but also has the added benefit that the templated configs are now valid YAML thus allowing checks with standard tools.
