### PR TITLE
New command: sv_metric_diff

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -103,6 +103,39 @@ will result in `/d/b/a`. Recommended use is to clean up ENV variables::
     PATH=`sv_remove_from_env /a/b/c:/a/b/d:/d/b/a /a/b`
 
 
+sv_metric_diff
+--------------------
+
+::
+
+    Usage: sv_metric_diff [OPTIONS] FILE_UNDER_TEST REFERENCE_FILE
+
+      Display the difference between two metric (JSON) files.
+
+      Examples:     sv_metric_diff
+      skvalidate/data/examples/performance_metrics*.json     sv_metric_diff
+      skvalidate/data/examples/file_metrics*.json
+
+    Options:
+      -o, --output-format [console|csv|markdown]
+      --help                          Show this message and exit.
+
+
+Example output:
+
+::
+
+    sv_metric_diff skvalidate/data/examples/file_metrics*
+    +-----------------------------------------+------------+---------+-------------+--------+-----------+--------+
+    | file                                    | metric     |   value |   ref value |   diff |   diff_pc | unit   |
+    |-----------------------------------------+------------+---------+-------------+--------+-----------+--------|
+    | continuous_integration_101.bin          | size_in_mb |    81   |        39.6 |   41.4 |  104.545  | MB     |
+    | continuous_integration_101.root         | size_in_mb |    14.3 |         9.4 |    4.9 |   52.1277 | MB     |
+    | continuous_integration_101_mctruth.root | size_in_mb |    90.3 |        31.9 |   58.4 |  183.072  | MB     |
+    +-----------------------------------------+------------+---------+-------------+--------+-----------+--------+
+
+
+
 sv_root_diff
 --------------------
 Calculates the difference between two ROOT (https://root.cern.ch/) files.

--- a/skvalidate/commands/metric_diff.py
+++ b/skvalidate/commands/metric_diff.py
@@ -20,8 +20,10 @@ def print_console(results, **kwargs):
     to_print = results[results.metric != 'size_in_bytes']
     print(tabulate(to_print, headers='keys', tablefmt='psql', showindex=False))
 
+
 def print_csv(results, **kwargs):
     print(results.to_csv(index=False))
+
 
 def print_markdown(results, **kwargs):
     title = kwargs.pop('title')
@@ -32,11 +34,13 @@ def print_markdown(results, **kwargs):
         template = Template(f.read())
     print(template.render(comparison=results))
 
+
 OUTPUT = dict(
     console=print_console,
     csv=print_csv,
     markdown=print_markdown,
 )
+
 
 def expand_results(results, title_desc):
     """Creates one row per result & metric combination"""
@@ -49,7 +53,6 @@ def expand_results(results, title_desc):
     return pd.DataFrame(expanded_results, columns=headers)
 
 
-
 @click.command(help=__doc__)
 @click.argument('file_under_test', type=click.Path(exists=True))
 @click.argument('reference_file', type=click.Path(exists=True))
@@ -60,9 +63,9 @@ def cli(file_under_test, reference_file, output_format):
         test_data = json.load(f)
     with open(reference_file) as f:
         ref_data = json.load(f)
-    
+
     results = compare_metrics(test_data, ref_data)
-    
+
     metric_types = []
     for title, measurement in test_data.items():
         for name, metric in measurement.items():
@@ -72,15 +75,13 @@ def cli(file_under_test, reference_file, output_format):
                 metric_types.append('rss')
             if 'size' in name:
                 metric_types.append('size')
-    
+
     title = 'unknown'
     if 'time' in metric_types and 'rss' in metric_types:
         title = 'command'
     if 'size' in metric_types and 'rss' not in metric_types:
         title = 'file'
-    
+
     if not output_format == 'markdown':
         results = expand_results(results, title_desc=title)
     OUTPUT[output_format](results, title=title)
-        
-    

--- a/skvalidate/commands/metric_diff.py
+++ b/skvalidate/commands/metric_diff.py
@@ -1,0 +1,86 @@
+"""
+    Display the difference between two metric (JSON) files.
+
+    Examples:
+        sv_metric_diff skvalidate/data/examples/performance_metrics*.json
+        sv_metric_diff skvalidate/data/examples/file_metrics*.json
+"""
+import json
+import os
+
+import click
+from jinja2 import Template
+import pandas as pd
+from tabulate import tabulate
+
+from skvalidate.compare import compare_metrics
+from skvalidate import __skvalidate_root__
+
+def print_console(results, **kwargs):
+    to_print = results[results.metric != 'size_in_bytes']
+    print(tabulate(to_print, headers='keys', tablefmt='psql', showindex=False))
+
+def print_csv(results, **kwargs):
+    print(results.to_csv(index=False))
+
+def print_markdown(results, **kwargs):
+    title = kwargs.pop('title')
+    template_file = 'file_metrics.md' if title == 'file' else 'performance.md'
+    path = [__skvalidate_root__, 'data', 'templates', 'report', 'default', template_file]
+    template_file = os.path.join(*path)
+    with open(template_file) as f:
+        template = Template(f.read())
+    print(template.render(comparison=results))
+
+OUTPUT = dict(
+    console=print_console,
+    csv=print_csv,
+    markdown=print_markdown,
+)
+
+def expand_results(results, title_desc):
+    """Creates one row per result & metric combination"""
+    expanded_results = []
+    headers = [title_desc, 'metric', 'value', 'ref value', 'diff', 'diff_pc', 'unit']
+    for title, measurement in results.items():
+        for name, metric in measurement.items():
+            result = [title, name, metric['value'], metric['ref'], metric['diff'], metric['diff_pc'], metric['unit']]
+            expanded_results.append(result)
+    return pd.DataFrame(expanded_results, columns=headers)
+
+
+
+@click.command(help=__doc__)
+@click.argument('file_under_test', type=click.Path(exists=True))
+@click.argument('reference_file', type=click.Path(exists=True))
+@click.option('-o', '--output-format', type=click.Choice(['console', 'csv', 'markdown']), default='console')
+def cli(file_under_test, reference_file, output_format):
+    results = {}
+    with open(file_under_test) as f:
+        test_data = json.load(f)
+    with open(reference_file) as f:
+        ref_data = json.load(f)
+    
+    results = compare_metrics(test_data, ref_data)
+    
+    metric_types = []
+    for title, measurement in test_data.items():
+        for name, metric in measurement.items():
+            if 'time' in name:
+                metric_types.append('time')
+            if 'rss' in name:
+                metric_types.append('rss')
+            if 'size' in name:
+                metric_types.append('size')
+    
+    title = 'unknown'
+    if 'time' in metric_types and 'rss' in metric_types:
+        title = 'command'
+    if 'size' in metric_types and 'rss' not in metric_types:
+        title = 'file'
+    
+    if not output_format == 'markdown':
+        results = expand_results(results, title_desc=title)
+    OUTPUT[output_format](results, title=title)
+        
+    


### PR DESCRIPTION
- comparing file & performance metric without full-blown report
- output formats: console, csv, markdown


# Example output:
## console
```
sv_metric_diff skvalidate/data/examples/file_metrics*
    +-----------------------------------------+------------+---------+-------------+--------+-----------+--------+
    | file                                    | metric     |   value |   ref value |   diff |   diff_pc | unit   |
    |-----------------------------------------+------------+---------+-------------+--------+-----------+--------|
    | continuous_integration_101.bin          | size_in_mb |    81   |        39.6 |   41.4 |  104.545  | MB     |
    | continuous_integration_101.root         | size_in_mb |    14.3 |         9.4 |    4.9 |   52.1277 | MB     |
    | continuous_integration_101_mctruth.root | size_in_mb |    90.3 |        31.9 |   58.4 |  183.072  | MB     |
    +-----------------------------------------+------------+---------+-------------+--------+-----------+--------+
```
## CSV
```
sv_metric_diff skvalidate/data/examples/file_metrics*  -o csv
file,metric,value,ref value,diff,diff_pc,unit
continuous_integration_101.bin,size_in_bytes,84890132.0,41487008.0,43403124.0,104.61859288575353,B
continuous_integration_101.bin,size_in_mb,81.0,39.6,41.4,104.54545454545455,MB
continuous_integration_101.root,size_in_bytes,14951803.0,9857661.0,5094142.0,51.67698503732275,B
continuous_integration_101.root,size_in_mb,14.3,9.4,4.9,52.12765957446809,MB
continuous_integration_101_mctruth.root,size_in_bytes,94735343.0,33443533.0,61291810.0,183.2695427244484,B
continuous_integration_101_mctruth.root,size_in_mb,90.3,31.9,58.4,183.07210031347964,MB
```

## Markdown
### Disk size report
| File | metric | value | ref value | diff |
|------|:-------|------:|----------:|-----:|
| `continuous_integration_101.bin` | size&#95;in&#95;bytes (B) | 84890132.00 | 41487008.00 | 43403124.00 (104.62 %)  |
| `continuous_integration_101.bin` | size&#95;in&#95;mb (MB) | 81.00 | 39.60 | 41.40 (104.55 %)  |
| `continuous_integration_101.root` | size&#95;in&#95;bytes (B) | 14951803.00 | 9857661.00 | 5094142.00 (51.68 %)  |
| `continuous_integration_101.root` | size&#95;in&#95;mb (MB) | 14.30 | 9.40 | 4.90 (52.13 %)  |
| `continuous_integration_101_mctruth.root` | size&#95;in&#95;bytes (B) | 94735343.00 | 33443533.00 | 61291810.00 (183.27 %)  |
| `continuous_integration_101_mctruth.root` | size&#95;in&#95;mb (MB) | 90.30 | 31.90 | 58.40 (183.07 %)  |
